### PR TITLE
fix:catch dns resolveSrv error

### DIFF
--- a/src/naming.ts
+++ b/src/naming.ts
@@ -99,7 +99,7 @@ export class DNSWatcher extends EventEmitter implements Watcher {
   }
 
   private async update(): Promise<void> {
-    let addrs = _.values(this.addrMap)
+    let addrs = _.values(this.addrMap);
     try {
       addrs = await this.resolveAddrs();
     } catch (err) {

--- a/src/naming.ts
+++ b/src/naming.ts
@@ -99,7 +99,12 @@ export class DNSWatcher extends EventEmitter implements Watcher {
   }
 
   private async update(): Promise<void> {
-    const addrs = await this.resolveAddrs();
+    let addrs = _.values(this.addrMap)
+    try {
+      addrs = await this.resolveAddrs();
+    } catch (err) {
+      log('dns resolve error: %s', err.message);
+    }
 
     const newAddrMap = _.keyBy(addrs, 'addr');
 


### PR DESCRIPTION
dns.resolveSrv  返回 error ，DNSWatcher update() 跳出循环，无法正常更新。